### PR TITLE
Reduce build times by disabling default features for fhir-sdk.

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -10,7 +10,7 @@ permissions:
   
 jobs:
   build:
-    runs-on: 4xl
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: 4xl
+    runs-on: ubuntu-latest
           
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ actix-web = "4"
 base64 = "0.22.1"
 chrono = "*"
 env_logger = "*"
-fhir-sdk = { version = "*", features = ["r4b"] }
+fhir-sdk = { version = "*", default-features = false, features = ["r4b", "client"] }
 futures = "*"
 http = "*"
 log = "*"


### PR DESCRIPTION
This commit disables the default features in the `fhir-sdk` crate, which includes the R5 FHIR resources. By disabling the unused API versions, we reduce build times by 30-50%.

Resolves #8.

Before change:
```
cargo build  346.80s user 19.06s system 254% cpu 2:23.72 total
```

After change:
```
cargo build  213.42s user 12.53s system 298% cpu 1:15.75 total
```